### PR TITLE
Retirement urls fixed to match

### DIFF
--- a/dataquality/tests/test_views.py
+++ b/dataquality/tests/test_views.py
@@ -693,180 +693,180 @@ class LegislativesessioninfoViewTest(TestCase):
         self.assertEqual(len(voteevent_orgs_list), 0)
 
 
-# class RetireLegislatorsViewTest(TestCase):
+class RetireLegislatorsViewTest(TestCase):
 
-#     def setUp(self):
-#         division = Division.objects.create(
-#             id='ocd-division/country:us', name='USA')
-#         jur = Jurisdiction.objects.create(
-#                 id="ocd-division/country:us/state:mo",
-#                 name="Missouri State Senate",
-#                 url="http://www.senate.mo.gov",
-#                 division=division,
-#             )
-#         person = Person.objects.create(name="Hitesh Garg")
-#         org1 = Organization.objects.create(name="Democratic", jurisdiction=jur)
-#         org2 = Organization.objects.create(name="Republican", jurisdiction=jur)
-#         org3 = Organization.objects.create(name="House", jurisdiction=jur)
-#         org4 = Organization.objects.create(name="Senate", jurisdiction=jur)
-#         org5 = Organization.objects.create(name="Joint", jurisdiction=jur)
-#         Membership.objects.create(person=person, organization=org1,
-#                                   end_date='2017-12-25')
-#         Membership.objects.create(person=person, organization=org2,
-#                                   end_date='2017-12-23')
-#         Membership.objects.create(person=person, organization=org3)
-#         Membership.objects.create(person=person, organization=org4)
-#         Membership.objects.create(person=person, organization=org5)
+    def setUp(self):
+        division = Division.objects.create(
+            id='ocd-division/country:us', name='USA')
+        jur = Jurisdiction.objects.create(
+                id="ocd-division/country:us/state:mo",
+                name="Missouri State Senate",
+                url="http://www.senate.mo.gov",
+                division=division,
+            )
+        person = Person.objects.create(name="Hitesh Garg")
+        org1 = Organization.objects.create(name="Democratic", jurisdiction=jur)
+        org2 = Organization.objects.create(name="Republican", jurisdiction=jur)
+        org3 = Organization.objects.create(name="House", jurisdiction=jur)
+        org4 = Organization.objects.create(name="Senate", jurisdiction=jur)
+        org5 = Organization.objects.create(name="Joint", jurisdiction=jur)
+        Membership.objects.create(person=person, organization=org1,
+                                  end_date='2017-12-25')
+        Membership.objects.create(person=person, organization=org2,
+                                  end_date='2017-12-23')
+        Membership.objects.create(person=person, organization=org3)
+        Membership.objects.create(person=person, organization=org4)
+        Membership.objects.create(person=person, organization=org5)
 
-#     def test_view_response(self):
-#         jur = Jurisdiction.objects.get(id='ocd-division/country:us/state:mo')
-#         response = self.client.get(reverse('retire_legislators',
-#                                            args=(jur.id,)))
-#         self.assertEqual(response.status_code, 200)
-#         person = Person.objects.get(name="Hitesh Garg")
-#         self.assertTrue(person in response.context['people'].object_list)
+    def test_view_response(self):
+        jur = Jurisdiction.objects.get(id='ocd-division/country:us/state:mo')
+        response = self.client.get(reverse('retire_legislators',
+                                           args=(jur.id,)))
+        self.assertEqual(response.status_code, 200)
+        person = Person.objects.get(name="Hitesh Garg")
+        self.assertTrue(person in response.context['people'].object_list)
 
-#     def test_wrong_format_of_reitrement_date(self):
-#         jur = Jurisdiction.objects.get(id='ocd-division/country:us/state:mo')
-#         p = Person.objects.get(name="Hitesh Garg")
-#         # Suppose retirement_date == '2017-12-24' (This is not possible)
-#         url = reverse('retire_legislators', args=(jur.id,))
-#         data = {p.id: '2017-12-35'}
-#         response = self.client.post(url, data)
-#         # some basic checks
-#         self.assertTrue('jur_id' in response.context)
-#         self.assertTrue('people' in response.context)
-#         self.assertTrue('page_range' in response.context)
-#         # Memberships should not be updated
-#         mem = Membership.objects.filter(person=p, end_date='2017-12-35')
-#         self.assertQuerysetEqual(mem, [])
+    def test_wrong_format_of_reitrement_date(self):
+        jur = Jurisdiction.objects.get(id='ocd-division/country:us/state:mo')
+        p = Person.objects.get(name="Hitesh Garg")
+        # Suppose retirement_date == '2017-12-24' (This is not possible)
+        url = reverse('retire_legislators', args=(jur.id,))
+        data = {p.id: '2017-12-35'}
+        response = self.client.post(url, data)
+        # some basic checks
+        self.assertTrue('jur_id' in response.context)
+        self.assertTrue('people' in response.context)
+        self.assertTrue('page_range' in response.context)
+        # Memberships should not be updated
+        mem = Membership.objects.filter(person=p, end_date='2017-12-35')
+        self.assertQuerysetEqual(mem, [])
 
-#     def test_invalid_retirement_date(self):
-#         jur = Jurisdiction.objects.get(id='ocd-division/country:us/state:mo')
-#         p = Person.objects.get(name="Hitesh Garg")
-#         # Suppose retirement_date == '2017-12-24' (This is not possible)
-#         url = reverse('retire_legislators', args=(jur.id,))
-#         data = {p.id: '2017-12-24'}
-#         response = self.client.post(url, data)
-#         # some basic checks
-#         self.assertTrue('jur_id' in response.context)
-#         self.assertTrue('people' in response.context)
-#         self.assertTrue('page_range' in response.context)
-#         # Memberships should not be updated
-#         mem = Membership.objects.filter(person=p, end_date='2017-12-24')
-#         self.assertQuerysetEqual(mem, [])
+    def test_invalid_retirement_date(self):
+        jur = Jurisdiction.objects.get(id='ocd-division/country:us/state:mo')
+        p = Person.objects.get(name="Hitesh Garg")
+        # Suppose retirement_date == '2017-12-24' (This is not possible)
+        url = reverse('retire_legislators', args=(jur.id,))
+        data = {p.id: '2017-12-24'}
+        response = self.client.post(url, data)
+        # some basic checks
+        self.assertTrue('jur_id' in response.context)
+        self.assertTrue('people' in response.context)
+        self.assertTrue('page_range' in response.context)
+        # Memberships should not be updated
+        mem = Membership.objects.filter(person=p, end_date='2017-12-24')
+        self.assertQuerysetEqual(mem, [])
 
-#     def test_valid_retirement_date(self):
-#         jur = Jurisdiction.objects.get(id='ocd-division/country:us/state:mo')
-#         p = Person.objects.get(name="Hitesh Garg")
-#         org1 = Organization.objects.get(name="Democratic")
-#         # Suppose retirement_date == '2017-12-30'
-#         url = reverse('retire_legislators', args=(jur.id,))
-#         data = {p.id: '2017-12-30'}
-#         self.client.post(url, data)
-#         m1 = Membership.objects.get(organization=org1)
-#         self.assertEqual(m1.end_date, '2017-12-25')
-#         mem = Membership.objects.filter(person=p,
-#                                         end_date='2017-12-30').count()
-#         self.assertEqual(mem, 3)
+    def test_valid_retirement_date(self):
+        jur = Jurisdiction.objects.get(id='ocd-division/country:us/state:mo')
+        p = Person.objects.get(name="Hitesh Garg")
+        org1 = Organization.objects.get(name="Democratic")
+        # Suppose retirement_date == '2017-12-30'
+        url = reverse('retire_legislators', args=(jur.id,))
+        data = {p.id: '2017-12-30'}
+        self.client.post(url, data)
+        m1 = Membership.objects.get(organization=org1)
+        self.assertEqual(m1.end_date, '2017-12-25')
+        mem = Membership.objects.filter(person=p,
+                                        end_date='2017-12-30').count()
+        self.assertEqual(mem, 3)
 
 
-# class ListRetiredLegislatorsViewTest(TestCase):
+class ListRetiredLegislatorsViewTest(TestCase):
 
-#     def setUp(self):
-#         division = Division.objects.create(
-#             id='ocd-division/country:us', name='USA')
-#         jur = Jurisdiction.objects.create(
-#                 id="ocd-division/country:us/state:mo",
-#                 name="Missouri State Senate",
-#                 url="http://www.senate.mo.gov",
-#                 division=division,
-#             )
-#         person = Person.objects.create(name="Hitesh Garg")
-#         org1 = Organization.objects.create(name="Democratic", jurisdiction=jur)
-#         org2 = Organization.objects.create(name="Republican", jurisdiction=jur)
-#         org3 = Organization.objects.create(name="House", jurisdiction=jur)
-#         org4 = Organization.objects.create(name="Senate", jurisdiction=jur)
-#         org5 = Organization.objects.create(name="Joint", jurisdiction=jur)
-#         # Suppose retirement_date == '2017-12-30'
-#         Membership.objects.create(person=person, organization=org1,
-#                                   end_date='2017-12-25')
-#         Membership.objects.create(person=person, organization=org2,
-#                                   end_date='2017-12-30')
-#         Membership.objects.create(person=person, organization=org3,
-#                                   end_date='2017-12-30')
-#         Membership.objects.create(person=person, organization=org4,
-#                                   end_date='2017-12-30')
-#         Membership.objects.create(person=person, organization=org5,
-#                                   end_date='2017-12-30')
+    def setUp(self):
+        division = Division.objects.create(
+            id='ocd-division/country:us', name='USA')
+        jur = Jurisdiction.objects.create(
+                id="ocd-division/country:us/state:mo",
+                name="Missouri State Senate",
+                url="http://www.senate.mo.gov",
+                division=division,
+            )
+        person = Person.objects.create(name="Hitesh Garg")
+        org1 = Organization.objects.create(name="Democratic", jurisdiction=jur)
+        org2 = Organization.objects.create(name="Republican", jurisdiction=jur)
+        org3 = Organization.objects.create(name="House", jurisdiction=jur)
+        org4 = Organization.objects.create(name="Senate", jurisdiction=jur)
+        org5 = Organization.objects.create(name="Joint", jurisdiction=jur)
+        # Suppose retirement_date == '2017-12-30'
+        Membership.objects.create(person=person, organization=org1,
+                                  end_date='2017-12-25')
+        Membership.objects.create(person=person, organization=org2,
+                                  end_date='2017-12-30')
+        Membership.objects.create(person=person, organization=org3,
+                                  end_date='2017-12-30')
+        Membership.objects.create(person=person, organization=org4,
+                                  end_date='2017-12-30')
+        Membership.objects.create(person=person, organization=org5,
+                                  end_date='2017-12-30')
 
-#     def test_view_response(self):
-#         jur = Jurisdiction.objects.get(id='ocd-division/country:us/state:mo')
-#         person = Person.objects.get(name="Hitesh Garg")
-#         response = self.client.get(reverse('list_retired_legislators',
-#                                            args=(jur.id,)))
-#         self.assertEqual(response.status_code, 200)
-#         self.assertEqual(response.context['people'].object_list[0][0],
-#                          person)
-#         self.assertEqual(response.context['people'].object_list[0][1],
-#                          '2017-12-30')
+    def test_view_response(self):
+        jur = Jurisdiction.objects.get(id='ocd-division/country:us/state:mo')
+        person = Person.objects.get(name="Hitesh Garg")
+        response = self.client.get(reverse('list_retired_legislators',
+                                           args=(jur.id,)))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context['people'].object_list[0][0],
+                         person)
+        self.assertEqual(response.context['people'].object_list[0][1],
+                         '2017-12-30')
 
-#     def test_valid_update_in_retirement_date(self):
-#         jur = Jurisdiction.objects.get(id='ocd-division/country:us/state:mo')
-#         p = Person.objects.get(name="Hitesh Garg")
-#         org1 = Organization.objects.get(name="Democratic")
-#         url = reverse('list_retired_legislators', args=(jur.id,))
-#         data = {p.id: '2017-12-26'}
-#         self.client.post(url, data)
-#         m1 = Membership.objects.get(organization=org1)
-#         self.assertEqual(m1.end_date, '2017-12-25')
-#         mem = Membership.objects.filter(person=p,
-#                                         end_date='2017-12-26').count()
-#         self.assertEqual(mem, 4)
+    def test_valid_update_in_retirement_date(self):
+        jur = Jurisdiction.objects.get(id='ocd-division/country:us/state:mo')
+        p = Person.objects.get(name="Hitesh Garg")
+        org1 = Organization.objects.get(name="Democratic")
+        url = reverse('list_retired_legislators', args=(jur.id,))
+        data = {p.id: '2017-12-26'}
+        self.client.post(url, data)
+        m1 = Membership.objects.get(organization=org1)
+        self.assertEqual(m1.end_date, '2017-12-25')
+        mem = Membership.objects.filter(person=p,
+                                        end_date='2017-12-26').count()
+        self.assertEqual(mem, 4)
 
-#     def test_wrong_format_of_update_in_retirement_date(self):
-#         jur = Jurisdiction.objects.get(id='ocd-division/country:us/state:mo')
-#         p = Person.objects.get(name="Hitesh Garg")
-#         org1 = Organization.objects.get(name="Democratic")
-#         url = reverse('list_retired_legislators', args=(jur.id,))
-#         data = {p.id: '2017-12-56'}
-#         self.client.post(url, data)
-#         m1 = Membership.objects.get(organization=org1)
-#         self.assertEqual(m1.end_date, '2017-12-25')
-#         mem = Membership.objects.filter(person=p,
-#                                         end_date='2017-12-56').count()
-#         self.assertEqual(mem, 0)
-#         mem = Membership.objects.filter(person=p,
-#                                         end_date='2017-12-30').count()
-#         self.assertEqual(mem, 4)
+    def test_wrong_format_of_update_in_retirement_date(self):
+        jur = Jurisdiction.objects.get(id='ocd-division/country:us/state:mo')
+        p = Person.objects.get(name="Hitesh Garg")
+        org1 = Organization.objects.get(name="Democratic")
+        url = reverse('list_retired_legislators', args=(jur.id,))
+        data = {p.id: '2017-12-56'}
+        self.client.post(url, data)
+        m1 = Membership.objects.get(organization=org1)
+        self.assertEqual(m1.end_date, '2017-12-25')
+        mem = Membership.objects.filter(person=p,
+                                        end_date='2017-12-56').count()
+        self.assertEqual(mem, 0)
+        mem = Membership.objects.filter(person=p,
+                                        end_date='2017-12-30').count()
+        self.assertEqual(mem, 4)
 
-#     def test_invalid_update_in_retirement_date(self):
-#         jur = Jurisdiction.objects.get(id='ocd-division/country:us/state:mo')
-#         p = Person.objects.get(name="Hitesh Garg")
-#         org1 = Organization.objects.get(name="Democratic")
-#         url = reverse('list_retired_legislators', args=(jur.id,))
-#         data = {p.id: '2017-12-24'}
-#         self.client.post(url, data)
-#         m1 = Membership.objects.get(organization=org1)
-#         self.assertEqual(m1.end_date, '2017-12-25')
-#         mem = Membership.objects.filter(person=p,
-#                                         end_date='2017-12-24').count()
-#         self.assertEqual(mem, 0)
-#         mem = Membership.objects.filter(person=p,
-#                                         end_date='2017-12-30').count()
-#         self.assertEqual(mem, 4)
+    def test_invalid_update_in_retirement_date(self):
+        jur = Jurisdiction.objects.get(id='ocd-division/country:us/state:mo')
+        p = Person.objects.get(name="Hitesh Garg")
+        org1 = Organization.objects.get(name="Democratic")
+        url = reverse('list_retired_legislators', args=(jur.id,))
+        data = {p.id: '2017-12-24'}
+        self.client.post(url, data)
+        m1 = Membership.objects.get(organization=org1)
+        self.assertEqual(m1.end_date, '2017-12-25')
+        mem = Membership.objects.filter(person=p,
+                                        end_date='2017-12-24').count()
+        self.assertEqual(mem, 0)
+        mem = Membership.objects.filter(person=p,
+                                        end_date='2017-12-30').count()
+        self.assertEqual(mem, 4)
 
-#     def test_un_retire_a_legislator(self):
-#         jur = Jurisdiction.objects.get(id='ocd-division/country:us/state:mo')
-#         p = Person.objects.get(name="Hitesh Garg")
-#         org1 = Organization.objects.get(name="Democratic")
-#         url = reverse('list_retired_legislators', args=(jur.id,))
-#         data = {p.id: ''}
-#         self.client.post(url, data)
-#         m1 = Membership.objects.get(organization=org1)
-#         self.assertEqual(m1.end_date, '2017-12-25')
-#         mem = Membership.objects.filter(person=p, end_date='').count()
-#         self.assertEqual(mem, 4)
+    def test_un_retire_a_legislator(self):
+        jur = Jurisdiction.objects.get(id='ocd-division/country:us/state:mo')
+        p = Person.objects.get(name="Hitesh Garg")
+        org1 = Organization.objects.get(name="Democratic")
+        url = reverse('list_retired_legislators', args=(jur.id,))
+        data = {p.id: ''}
+        self.client.post(url, data)
+        m1 = Membership.objects.get(organization=org1)
+        self.assertEqual(m1.end_date, '2017-12-25')
+        mem = Membership.objects.filter(person=p, end_date='').count()
+        self.assertEqual(mem, 4)
 
 
 class CreatePersonPatchViewTest(TestCase):

--- a/dataquality/urls.py
+++ b/dataquality/urls.py
@@ -39,14 +39,16 @@ urlpatterns = [
         '(?P<issue_slug>[-\w]+)/(?P<action>[-\w]+)/$',
         views.dataquality_exceptions, name='dataquality_exceptions'),
 
-    # name resolution
-    url(r'^(?P<jur_id>[\w\-\:\/]+)/(?P<category>[-\w]+)/$',
-        views.name_resolution_tool, name='name_resolution_tool'),
-
     # retirement
     url(r'^(?P<jur_id>[\w\-\:\/]+)/retire-legislators/$',
         views.retire_legislators, name="retire_legislators"),
 
     url(r'^(?P<jur_id>[\w\-\:\/]+)/all-retired-legislators/$',
         views.list_retired_legislators, name="list_retired_legislators"),
+
+    # name resolution
+    url(r'^(?P<jur_id>[\w\-\:\/]+)/(?P<category>[-\w]+)/$',
+        views.name_resolution_tool, name='name_resolution_tool'),
+
+   
 ]

--- a/dataquality/urls.py
+++ b/dataquality/urls.py
@@ -49,6 +49,4 @@ urlpatterns = [
     # name resolution
     url(r'^(?P<jur_id>[\w\-\:\/]+)/(?P<category>[-\w]+)/$',
         views.name_resolution_tool, name='name_resolution_tool'),
-
-   
 ]

--- a/openstates/urls.py
+++ b/openstates/urls.py
@@ -10,7 +10,7 @@ urlpatterns = [
     url(r'^djadmin/', include('opencivicdata.core.admin.urls')),
     url(r'^graphql', csrf_exempt(GraphQLView.as_view(graphiql=True))),
     # url(r'^public/', include('public.urls')),
-    # url(r'^reports/', include('dataquality.urls'))
+    url(r'^reports/', include('dataquality.urls'))
 ]
 
 


### PR DESCRIPTION
resolves  #77 changed the orders of URLs to match the retirement-URLs.
@jamesturk I am not sure, if it fixes the issue, although all tests pass.