### PR TITLE
Consider classification when using optimized current_memberships

### DIFF
--- a/graphapi/core.py
+++ b/graphapi/core.py
@@ -136,6 +136,9 @@ class PersonNode(OCDBaseNode):
 
     def resolve_current_memberships(self, info, classification=None):
         if hasattr(self, 'current_memberships'):
+            if classification:
+                return [m for m in self.current_memberships
+                        if m.organization.classification in classification]
             return self.current_memberships
         else:
             return _current_membership_filter(self.memberships, info, classification)

--- a/graphapi/tests/test_core.py
+++ b/graphapi/tests/test_core.py
@@ -246,6 +246,28 @@ def test_people_num_queries(django_assert_num_queries):
 
 
 @pytest.mark.django_db
+def test_people_current_memberships_classification(django_assert_num_queries):
+    with django_assert_num_queries(3):
+        result = schema.execute(''' {
+        people(first: 50) {
+            edges {
+                node {
+                    currentMemberships(classification: "party") {
+                        organization { name }
+                    }
+                }
+            }
+        }
+        }''')
+    assert result.errors is None
+    assert len(result.data['people']['edges']) == 8
+    total_memberships = 0
+    for person in result.data['people']['edges']:
+        total_memberships += len(person['node']['currentMemberships'])
+    assert total_memberships == 8      # Only the 8 parties should be returned
+
+
+@pytest.mark.django_db
 def test_person_by_id(django_assert_num_queries):
     person = Person.objects.get(name='Bob Birch')
     with django_assert_num_queries(7):


### PR DESCRIPTION
We previously did not consider the classification argument when using the optimized current_memberships, meaning that if the optimized route was taken, the same set of data would be returned no matter what the classification argument was. We now consider it, fixing #89.